### PR TITLE
Fix code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/application.py
+++ b/application.py
@@ -88,16 +88,19 @@ def uploaded():
                 return render_template('error.html', err=err)
             else:
                 print(f"{Fore.GREEN}[+] file uploded ! {file_name}{Fore.RESET}")
-                path = f'{Path(__file__).parent}'
-                path_full_write = f"{path}\\files\{file_name}"
-                content = readfile(file_name)
+                base_path = os.path.abspath('./files')
+                path_full_write = os.path.normpath(os.path.join(base_path, file_name))
+                if not path_full_write.startswith(base_path):
+                    err = "Invalid file path"
+                    return render_template('error.html', err=err)
+                content = readfile(path_full_write)
                 writefile(path_full_write, content)
 
 
     return render_template('upload.html', file_content=file_content)
 
-def  readfile(file_name):
-    with open (file_name, "r") as fichier:
+def  readfile(full_path):
+    with open (full_path, "r") as fichier:
         content = fichier.read()
     return content
 
@@ -112,7 +115,12 @@ def process_file(file_name):
     #Chargement du fichier YAML
     if ".yaml" in file_name or ".yml" in file_name:
         try:
-            with open(file_name,'rb') as f:
+            base_path = os.path.abspath('./files')
+            full_path = os.path.normpath(os.path.join(base_path, file_name))
+            if not full_path.startswith(base_path):
+                err = "Invalid file path"
+                return err
+            with open(full_path,'rb') as f:
                 content = f.read()
                 data = yaml.load(content, Loader=yaml.FullLoader) # Using vulnerable FullLoader
         except Exception as er:


### PR DESCRIPTION
Fixes [https://github.com/MindRiddle/Formation-DSO/security/code-scanning/5](https://github.com/MindRiddle/Formation-DSO/security/code-scanning/5)

To fix the problem, we need to ensure that the file paths constructed from user input are properly validated and sanitized. This involves normalizing the path and ensuring that it is contained within a safe root directory. We will use `os.path.normpath` to normalize the path and then check if the resulting path starts with the intended base directory.

1. Normalize the file path using `os.path.normpath`.
2. Check if the normalized path starts with the intended base directory.
3. If the path is valid, proceed with the file operations; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
